### PR TITLE
fix: removing error throwing of expected behaviour

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -78,7 +78,7 @@ exports.addUserToList = functions.handler.auth.user.onCreate(
       );
       logs.complete();
     } catch (err) {
-      logs.errorAddUser(err);
+      err.title === 'Member Exists' ? logs.userAlreadyInAudience( ) : logs.errorAddUser(err);
     }
   }
 );
@@ -111,7 +111,7 @@ exports.removeUserFromList = functions.handler.auth.user.onDelete(
       logs.userRemoved(uid, hashed, config.mailchimpAudienceId);
       logs.complete();
     } catch (err) {
-      logs.errorRemoveUser(err);
+      err.title === 'Method Not Allowed' ? logs.userNotInAudience() : logs.errorRemoveUser(err);
     }
   }
 );

--- a/functions/logs.js
+++ b/functions/logs.js
@@ -14,15 +14,23 @@
  * limitations under the License.
  */
 
-const { logger } = require('firebase-functions');
-const config = require('./config');
+const { logger } = require("firebase-functions");
+const config = require("./config");
 
 module.exports = {
   complete: () => {
     logger.log("Completed execution of extension");
   },
+  userAlreadyInAudience: () => {
+    logger.log("Attempted added user already in mailchimp audience");
+  },
   errorAddUser: (err) => {
     logger.error("Error when adding user to Mailchimp audience", err);
+  },
+  userNotInAudience: () => {
+    logger.log(
+      "Attempted removal failed, member deletion not allowed. Probably because member has already been removed from audience"
+    );
   },
   errorRemoveUser: (err) => {
     logger.error("Error when removing user from Mailchimp audience", err);
@@ -61,5 +69,5 @@ module.exports = {
     logger.log(
       `Removing user: ${userId} with hashed email: ${hashedEmail} from Mailchimp audience: ${audienceId}`
     );
-  }
+  },
 };


### PR DESCRIPTION
This PR copies the functionality from https://github.com/firebase/extensions/pull/600

Calling `logger.error` with expected behaviour triggers errors on GCP logging, so instead we catch the error and log an expected message.