### PR TITLE
Sync subscription status

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,10 @@ Usage of this extension also requires you to have a Mailchimp account. You are r
 
   * Required Fields:
     1. `mergeFields` - JSON mapping representing the Firestore document fields to associate with Mailchimp Merge Fields.
+  
+    2. `statusField` - The Firestore document field of boolean type to reflect subscription status.
     
-    2. `subscriberEmail` - The Firestore document field capturing the user email as is recognized by Mailchimp
+    3. `subscriberEmail` - The Firestore document field capturing the user email as is recognized by Mailchimp
 
     Configuration Example:
     ``` 
@@ -102,6 +104,7 @@ Usage of this extension also requires you to have a Mailchimp account. You are r
         "lastName": "LNAME",
         "phoneNumber": "PHONE"
       },
+      "statusField": "subscribed",
       "subscriberEmail": "emailAddress"
     } 
     ```
@@ -112,6 +115,7 @@ Usage of this extension also requires you to have a Mailchimp account. You are r
       "firstName": "..", // The config property FNAME maps to this document field
       "lastName": "..", // The config property LNAME maps to this document field
       "phoneNumber": "..", // The config property PHONE maps to this document field
+      "subscribed": false, // The config property "statusField" maps to this document field
       "emailAddress": "..", // The config property "subscriberEmail" maps to this document field
       "jobTitle": "..", 
       "domainKnowledge": "..",

--- a/functions/index.js
+++ b/functions/index.js
@@ -44,7 +44,7 @@ try {
       }
       // Each feature config must include a property called "subscriberEmail"
       // which maps to the mailchimp user email in the Firestore document
-      if (!parsedConfig.subscriberEmail) {
+      if (!_.isEmpty(parsedConfig) && !parsedConfig.subscriberEmail) {
         logError(`${key} requires a property named 'subscriberEmail'`);
       }
       // persist the serialized JSON

--- a/functions/index.js
+++ b/functions/index.js
@@ -129,8 +129,8 @@ exports.removeUserFromList = functions.handler.auth.user.onDelete(
   }
 );
 
-exports.memberTagsHandler = functions.handler.firestore.document
-  .onWrite(async (event, context) => {
+exports.memberTagsHandler = functions.handler.firestore.document.onWrite(
+  async (event) => {
     // If an empty JSON configuration was provided then consider function as NO-OP
     if (_.isEmpty(config.mailchimpMemberTags)) return null;
 
@@ -189,8 +189,8 @@ exports.memberTagsHandler = functions.handler.firestore.document
     }
   });
 
-exports.mergeFieldsHandler = functions.handler.firestore.document
-  .onWrite(async (event, context) => {
+exports.mergeFieldsHandler = functions.handler.firestore.document.onWrite(
+  async (event) => {
     // If an empty JSON configuration was provided then consider function as NO-OP
     if (_.isEmpty(config.mailchimpMergeField)) return null;
 
@@ -245,8 +245,8 @@ exports.mergeFieldsHandler = functions.handler.firestore.document
     }
   });
 
-exports.memberEventsHandler = functions.handler.firestore.document
-  .onWrite(async (event, context) => {
+exports.memberEventsHandler = functions.handler.firestore.document.onWrite(
+  async (event) => {
     // If an empty JSON configuration was provided then consider function as NO-OP
     if (_.isEmpty(config.mailchimpMemberEvents)) return null;
 

--- a/functions/package.json
+++ b/functions/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "firebase-admin": "9.5.0",
     "firebase-functions": "3.13.2",
-    "lodash": "4.17.20",
+    "lodash": "^4.17.20",
     "mailchimp-api-v3": "1.15.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Allow to sync subscription status (#14) and fix a few small things:
- Suppress warnings about missing `subscriberEmail` key in empty configurations
- Compute subscriber hash from lowercase email
- Remove `context` parameter not available in handler namespace
- Allow using higher versions of `lodash`