### PR TITLE
Add status_if_new in case of mergeFields

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -233,6 +233,7 @@ exports.mergeFieldsHandler = functions.handler.firestore.document
 
       const params = {
         email_address: newDoc[mergeFieldsConfig.subscriberEmail],
+        status_if_new: config.mailchimpContactStatus,
         merge_fields: mergeFieldsToUpdate
       };
 


### PR DESCRIPTION
If I add merge information on a collection but the user dont have Auth yet don't work, so adding if_user_new fix this issue.