### PR TITLE
Support multidimensional (nested) arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Usage of this extension also requires you to have a Mailchimp account. You are r
   * Required Fields:
   
     1. `memberTags` - The Firestore document fields(s) to retrieve data from and classify as subscriber tags in Mailchimp. Acceptable data types include:
-        - `Array<String>` - The extension will lookup the values in the provided fields and update the subscriber's member tags with the respective data values.
+        - `Array<String | { path: String, key: String }>` - The extension will lookup the values in the provided fields and update the subscriber's member tags with the respective data values.
 
         - `String` - The extension will lookup the value in the provided field and update the subscriber's member tags with the provided value.
 

--- a/extension.yaml
+++ b/extension.yaml
@@ -220,7 +220,7 @@ params:
 
       1) `memberTags` - The Firestore document fields(s) to retrieve data from and classify as subscriber tags in Mailchimp. Acceptable data types include:
       
-      - Array\<String\> - The extension will lookup the values in the provided fields and update the subscriber's member tags with the respective data values.
+      - Array\<String | { path: String, key: String }\> - The extension will lookup the values in the provided fields and update the subscriber's member tags with the respective data values.
 
 
       - String - The extension will lookup the value in the provided field and update the subscriber's member tags with the provided value.

--- a/functions/index.js
+++ b/functions/index.js
@@ -159,9 +159,16 @@ exports.memberTagsHandler = functions.handler.firestore.document
       const prevDoc = event && event.before && event.before.data();
       const newDoc = event && event.after && event.after.data();
 
+      // Check if we are dealing with a multidimensional array
+      const isMultidimensional = (tag) =>
+        typeof tag === "object" && typeof tag.path !== "undefined" && typeof tag.key !== "undefined"
+
       // Retrieves subscriber tags before/after write event
       const getTagsFromEventSnapshot = snapshot => tagsConfig.memberTags.reduce((acc, tag) => {
-        const tags = _.get(snapshot, tag);
+        const tags = isMultidimensional(tag)
+          ? _.get(snapshot, tag.path).map((parent) => parent[tag.key])
+          : _.get(snapshot, tag);
+          
         if (Array.isArray(tags) && tags && tags.length) {
           acc = [...acc, ...tags];
         } else if (tags) {

--- a/functions/tests/memberTagsHandler.test.js
+++ b/functions/tests/memberTagsHandler.test.js
@@ -183,6 +183,50 @@ describe("memberTagsHandler", () => {
     );
   });
 
+  it("should set tags from multidimensional nested config for new user", async () => {
+    configureApi({
+      ...defaultConfig,
+      mailchimpMemberTags: JSON.stringify({
+        memberTags: ["tag_data.field_1", { path: "tag_data.field_2", key: "value" }],
+        subscriberEmail: "emailAddress",
+      }),
+    });
+    const wrapped = testEnv.wrap(api.memberTagsHandler);
+
+    const testUser = {
+      uid: "122",
+      displayName: "lee",
+      emailAddress: "test@example.com",
+      tag_data: {
+        field_1: "tagValue1",
+        field_2: [
+          { label : "label_1", value: "value_1" },
+          { label : "label_2", value: "value_2" },
+          { label : "label_3", value: "value_3" },
+        ],
+      },
+    };
+
+    const result = await wrapped({
+      after: {
+        data: () => testUser,
+      },
+    });
+
+    expect(result).toBe(undefined);
+    expect(mailchimpMock.__mocks.post).toHaveBeenCalledWith(
+      "/lists/mailchimpAudienceId/members/55502f40dc8b7c769880b10874abc9d0/tags",
+      {
+        tags: [
+          { name: "tagValue1", status: "active" },
+          { name: "value_1", status: "active" },
+          { name: "value_2", status: "active" },
+          { name: "value_3", status: "active" },
+        ],
+      }
+    );
+  });
+
   it("should update tags for changed user", async () => {
     configureApi({
       ...defaultConfig,


### PR DESCRIPTION
In our application during registration a user can select multiple option. These options are stored in a multidimensional array. We want to be able to get the value of each field in the given path.

Take for example the following document:

```
{
  field_1: "tagValue1",
  field_2: [
    { label : "label_1", value: "value_1" },
    { label : "label_2", value: "value_2" },
    { label : "label_3", value: "value_3" },
  ]
}
```

From this we want to extract `field_1` and every `value` of `field_2`. The end result will look like this:

```
{
  tags: [
    { name: "tagValue1", status: "active" },
    { name: "value_1", status: "active" },
    { name: "value_2", status: "active" },
    { name: "value_3", status: "active" },
  ],
}
```

The value for `memberTags` will look like this: `["tag_data.field_1", { path: "tag_data.field_2", key: "value" }]`.