### PR TITLE
Sync status via merge field trigger.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added configuration validation via JSON Schema (PR #54)
 - Support extended configuration for Merge Fields, so that fields can be set to continuously sync even when not changed (PR #55)
 - Dependencies bump (#56)
+- Support updating mailchimp subscription status via merge field trigger (PR #56)
 
 ## Version 0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Support extended syntax for configurations of Member Tags and Member Events, to allow multidimensional arrays to be unwrapped (PR #53)
 - Added configuration validation via JSON Schema (PR #54)
 - Support extended configuration for Merge Fields, so that fields can be set to continuously sync even when not changed (PR #55)
-- Dependencies bump (#56)
+- Dependencies bump (PR #56)
 - Support updating mailchimp subscription status via merge field trigger (PR #57)
 
 ## Version 0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Added configuration validation via JSON Schema (PR #54)
 - Support extended configuration for Merge Fields, so that fields can be set to continuously sync even when not changed (PR #55)
 - Dependencies bump (#56)
-- Support updating mailchimp subscription status via merge field trigger (PR #56)
+- Support updating mailchimp subscription status via merge field trigger (PR #57)
 
 ## Version 0.4.0
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,15 @@ Usage of this extension also requires you to have a Mailchimp account. You are r
         - `mailchimpFieldName` - (required) The name of the Mailchimp Merge Field to map to, e.g. "FNAME".
         - `when` - (optional) When to send the value of the field to Mailchimp. Options are "always" (which will send the value of this field on _any_ change to the document, not just this field) or "changed". Default is "changed".
 
-    2. `subscriberEmail` - The Firestore document field capturing the user email as is recognized by Mailchimp
+    2. `statusField` - An optional configuration setting for syncing the users mailchimp status. Properties are:
+
+        - `documentPath` - (required) The path to the field in the document containing the users status. This additionally accepts nested object paths. e.g. "status", "meta.status".
+        - `statusFormat` - (optional) Indicates the format that the status field is. The options are:
+
+            - `"string"` - The default, this will sync the value from the status field as is, with no modification.
+            - `"boolean"` - This will check if the value is truthy (e.g. true, 1, "subscribed"), and if so will resolve the status to "subscribed", otherwise it will resolve to "unsubscribed".
+
+    3. `subscriberEmail` - The Firestore document field capturing the user email as is recognized by Mailchimp
 
     Configuration Example:
 

--- a/extension.yaml
+++ b/extension.yaml
@@ -321,8 +321,15 @@ params:
       
       - `when` - (optional) When to send the value of the field to Mailchimp. Options are "always" (which will send the value of this field on _any_ change to the document, not just this field) or "changed". Default is "changed".
 
+      2) `statusField` - An optional configuration setting for syncing the users mailchimp status. Properties are:
 
-      2) `subscriberEmail` - The Firestore document field capturing the user email as is recognized by Mailchimp
+      - `documentPath` - (required) The path to the field in the document containing the users status. This additionally accepts nested object paths. e.g. "status", "meta.status".
+      
+      - `statusFormat` - (optional) Indicates the format that the status field is. The options are:
+          - `"string"` - The default, this will sync the value from the status field as is, with no modification.
+          - `"boolean"` - This will check if the value is truthy (e.g. true, 1, "subscribed"), and if so will resolve the status to "subscribed", otherwise it will resolve to "unsubscribed".
+
+      3) `subscriberEmail` - The Firestore document field capturing the user email as is recognized by Mailchimp
 
 
       Configuration Example:

--- a/functions/validation.js
+++ b/functions/validation.js
@@ -70,6 +70,14 @@ const mergeFieldsConfigSchema = {
         ],
       },
     },
+    statusField: {
+      type: "object",
+      properties: {
+        documentPath: { type: "string" },
+        statusFormat: { type: "string", enum: ["boolean", "string"] },
+      },
+      required: ["documentPath"],
+    },
     subscriberEmail: { type: "string" },
   },
   required: ["mergeFields", "subscriberEmail"],


### PR DESCRIPTION
The endpoint that receives merge field updates can additionally update the status of the user.
Additional configuration has been added to be able to specify the field the status value is stored in, as well as whether to interpret the value as a boolean or string, for easy integration with "subscribed": true/false type set ups.